### PR TITLE
core: Add option to toggle minimap icon on/off

### DIFF
--- a/pfDatabase.lua
+++ b/pfDatabase.lua
@@ -28,6 +28,7 @@ SlashCmdList["PFDB"] = function(input, editbox)
     DEFAULT_CHAT_FRAME:AddMessage("/db quest <questname> |cffaaaaaa - show specific questgiver")
     DEFAULT_CHAT_FRAME:AddMessage("/db quests <area> |cffaaaaaa - show all quest spots on the map")
     DEFAULT_CHAT_FRAME:AddMessage("/db clean |cffaaaaaa - clean map")
+    DEFAULT_CHAT_FRAME:AddMessage("/db minimap |cffaaaaaa - toggle minimap button on/off")
   end
 
   local commandlist = { }
@@ -103,6 +104,17 @@ SlashCmdList["PFDB"] = function(input, editbox)
   -- argument: show
   if (arg1 == "config") then
     if pfQuestConfig then pfQuestConfig:Show() end
+  end
+
+
+  -- argument: show
+  if (arg1 == "minimap") then
+    if (pfQuest_config.minimapicon == "1") then
+      pfQuest_config.minimapicon = "0"
+    else
+      pfQuest_config.minimapicon = "1"
+    end
+    pfQuestConfig.onToggleFunctions.minimapicon()
   end
 end
 

--- a/pfQuest.lua
+++ b/pfQuest.lua
@@ -7,6 +7,7 @@ pfQuest_defconfig = {
   ["minimapnodes"] = "1", -- hide all minimap entries
   ["questlogbuttons"] = "1", -- shows buttons inside the questlog
   ["worldmapmenu"] = "1", -- shows the dropdown selection in worldmap
+  ["minimapicon"] = "1",
   ["worldmaptransp"] = "1.0",
   ["minimaptransp"] = "1.0",
 }

--- a/pfQuestConfig.lua
+++ b/pfQuestConfig.lua
@@ -37,8 +37,8 @@ local function CreateConfigEntry(config, description, type)
         pfQuest_config[this.config] = "0"
       end
       -- run option specific function, if it exists
-      if onClickFunctions[this.config] ~= nil then
-          onClickFunctions[this.config]()
+      if pfQuestConfig.onToggleFunctions[this.config] ~= nil then
+          pfQuestConfig.onToggleFunctions[this.config]()
       end
     end)
 
@@ -110,8 +110,8 @@ pfQuestConfig.close:SetScript("OnClick", function()
 end)
 
 -- If changing an option without reloading the UI needs some action, it can be defined in this table
-onClickFunctions = {}
-onClickFunctions.minimapicon = function()
+pfQuestConfig.onToggleFunctions = {}
+pfQuestConfig.onToggleFunctions.minimapicon = function()
   if pfQuest_config["minimapicon"] == "1" then
     pfBrowserIcon:Show()
   else

--- a/pfQuestConfig.lua
+++ b/pfQuestConfig.lua
@@ -30,10 +30,15 @@ local function CreateConfigEntry(config, description, type)
     end
 
     frame.input:SetScript("OnClick", function ()
+      -- change the option
       if this:GetChecked() then
         pfQuest_config[this.config] = "1"
       else
         pfQuest_config[this.config] = "0"
+      end
+      -- run option specific function, if it exists
+      if onClickFunctions[this.config] ~= nil then
+          onClickFunctions[this.config]()
       end
     end)
 
@@ -66,7 +71,7 @@ end
 pfQuestConfig = CreateFrame("Frame", "pfQuestConfig", UIParent)
 pfQuestConfig:Hide()
 pfQuestConfig:SetWidth(280)
-pfQuestConfig:SetHeight(340)
+pfQuestConfig:SetHeight(370)
 pfQuestConfig:SetPoint("CENTER", 0, 0)
 pfQuestConfig:SetFrameStrata("TOOLTIP")
 pfQuestConfig:SetMovable(true)
@@ -104,15 +109,29 @@ pfQuestConfig.close:SetScript("OnClick", function()
  this:GetParent():Hide()
 end)
 
+-- If changing an option without reloading the UI needs some action, it can be defined in this table
+onClickFunctions = {}
+onClickFunctions.minimapicon = function()
+  if pfQuest_config["minimapicon"] == "1" then
+    pfBrowserIcon:Show()
+  else
+    pfBrowserIcon:Hide()
+  end
+end
+
 pfQuestConfig:RegisterEvent("ADDON_LOADED")
 pfQuestConfig:SetScript("OnEvent", function()
   if arg1 == "pfQuest" then
+    if pfQuest_config["minimapicon"] == "0" then
+      pfBrowserIcon:Hide()
+    end
     CreateConfigEntry("allquestgivers",      "Show Available Questgivers",     "checkbox")
     CreateConfigEntry("currentquestgivers",  "Show Current Questgiver Nodes",  "checkbox")
     CreateConfigEntry("showlowlevel",        "Show Lowlevel Questgiver Nodes", "checkbox")
     CreateConfigEntry("minimapnodes",        "Show MiniMap Nodes",             "checkbox")
     CreateConfigEntry("questlogbuttons",     "Show QuestLog Buttons",          "checkbox")
     CreateConfigEntry("worldmapmenu",        "Show WorldMap Menu",             "checkbox")
+    CreateConfigEntry("minimapicon",         "Show MiniMap Icon",              "checkbox")
     CreateConfigEntry("worldmaptransp",      "WorldMap Node Transparency",     "text")
     CreateConfigEntry("minimaptransp",       "MiniMap Node Transparency",      "text")
   end


### PR DESCRIPTION
#This fixes #6 and fixes #43 (duplicate).

Switching the option in the config menu has immediate effect and does not require a `ReloadUI()` (config can be closed with X-button instead of "Close & Reload"-Button).