### PR TITLE
Pf quest 3.0 additions Number 2

### DIFF
--- a/browser.lua
+++ b/browser.lua
@@ -105,6 +105,8 @@ local function CreateResultEntry(i, resultType)
   f.text = f:CreateFontString("Caption", "LOW", "GameFontWhite")
   f.text:SetAllPoints(f)
   f.text:SetJustifyH("CENTER")
+  f.idText = f:CreateFontString("ID", "LOW", "GameFontDisable")
+  f.idText:SetPoint("LEFT", f, "LEFT", 30, 0)
 
   -- favourite button
   f.fav = CreateFrame("Button", nil, f)
@@ -149,6 +151,7 @@ local function CreateResultEntry(i, resultType)
       this.tex:SetTexture(1,1,1,.1)
       GameTooltip:SetOwner(this.text, "ANCHOR_LEFT", -10, -5)
       GameTooltip:SetHyperlink("item:" .. this.id .. ":0:0:0")
+      GameTooltip:AddLine("\nID: "..this.id, 0.8,0.8,0.8)
       GameTooltip:Show()
     end)
 
@@ -336,6 +339,7 @@ local function CreateResultEntry(i, resultType)
       if questTexts["D"] and questTexts["D"] ~= "" then
         GameTooltip:AddLine("\n|cffffff00Details: |r"..ReplaceQuestDetailWildcards(questTexts["D"]), .6,1,.9,true)
       end
+      GameTooltip:AddLine("\nID: "..this.id, 0.8,0.8,0.8)
       GameTooltip:Show()
     end)
 
@@ -391,6 +395,7 @@ local function CreateResultEntry(i, resultType)
       for zone, count in pairs(maps) do
         GameTooltip:AddDoubleLine(( zone and pfMap:GetMapNameByID(zone) or UNKNOWN), count .. "x", 1,1,1, .5,.5,.5)
       end
+      GameTooltip:AddLine("\nID: "..this.id, 0.8,0.8,0.8)
       GameTooltip:Show()
     end)
 
@@ -575,6 +580,12 @@ pfBrowser.input:SetScript("OnTextChanged", function()
         end
         local button = pfBrowser.tabs[searchType].buttons[i]
         button.id = id
+        if pfQuest_config.showids == "1" then
+          button.idText:SetText("ID: "..id)
+          button.idText:Show()
+        else
+          button.idText:Hide()
+        end
         local nameOrQuestLoc = pfDB[searchType]["loc"][id]
         -- handle faction icons
         if (searchType ~= "items") then

--- a/browser.lua
+++ b/browser.lua
@@ -279,19 +279,19 @@ local function CreateResultEntry(i, resultType)
       f[key].icon:SetTexture("Interface\\AddOns\\pfQuest\\img\\"..values.icon)
       f[key]:SetScript("OnClick", function()
         local param = this:GetParent()[this.parameter]
+        local maps
         if this.buttonType == "O" or this.buttonType == "U" then
-          pfDatabase:SearchItemID(param)
+          maps = pfDatabase:SearchItemID(param)
         elseif this.buttonType == "V" then
-          pfDatabase:SearchVendor(param)
+          maps = pfDatabase:SearchVendor(param)
         --[[TODO: add extractor support and implement functions
         elseif this.buttonType == "Q" then
-          pfDatabase:SearchQuestRewards(param)
+          maps = pfDatabase:SearchQuestRewards(param)
         elseif this.buttonType == "I" then
-          pfDatabase:SearchItemsInItems(param)--]]
+          maps = pfDatabase:SearchItemsInItems(param)--]]
         end
-        local map = values.mapFunction(param)
         pfMap:UpdateNodes()
-        pfMap:ShowMapID(map)
+        pfMap:ShowMapID(pfDatabase:GetBestMap(maps))
       end)
       f[key]:SetScript("OnEnter", values.OnEnter)
       f[key]:SetScript("OnLeave", function()
@@ -320,11 +320,11 @@ local function CreateResultEntry(i, resultType)
     f:SetScript("OnClick", function()
       if IsShiftKeyDown() then
         ChatFrameEditBox:Show()
-        ChatFrameEditBox:Insert("|cffffff00|Hquest:0:0:0:0|h[" .. this.questname .. "]|h|r")
+        ChatFrameEditBox:Insert("|cffffff00|Hquest:0:0:0:0|h[" .. this.name .. "]|h|r")
       else
         local meta = { ["addon"] = "PFDB" }
-        local map = pfDatabase:SearchQuest(this.quest, meta, true)
-        pfMap:ShowMapID(map)
+        local maps = pfDatabase:SearchQuestID(this.id, meta)
+        pfMap:ShowMapID(pfDatabase:GetBestMap(maps))
       end
     end) -- end of quests
   -- units and objects
@@ -350,11 +350,19 @@ local function CreateResultEntry(i, resultType)
       GameTooltip:Show()
     end)
 
-    f:SetScript("OnClick", function()
-      local map = pfDatabase:SearchMob(this.name)
-      pfMap:UpdateNodes()
-      pfMap:ShowMapID(map)
-    end)
+    if resultType == "units" then
+      f:SetScript("OnClick", function()
+        local maps = pfDatabase:SearchMobID(this.id)
+        pfMap:UpdateNodes()
+        pfMap:ShowMapID(pfDatabase:GetBestMap(maps))
+      end)
+    elseif resultType == "objects" then
+      f:SetScript("OnClick", function()
+        local maps = pfDatabase:SearchObjectID(this.id)
+        pfMap:UpdateNodes()
+        pfMap:ShowMapID(pfDatabase:GetBestMap(maps))
+      end)
+    end
   end -- end of units and objects
   return f
 end

--- a/browser.lua
+++ b/browser.lua
@@ -284,7 +284,7 @@ local function CreateResultEntry(i, resultType)
         local param = this:GetParent()[this.parameter]
         local maps
         if this.buttonType == "O" or this.buttonType == "U" then
-          maps = pfDatabase:SearchItemID(param)
+          maps = pfDatabase:SearchItemID(param, nil, nil, {[this.buttonType]=true})
         elseif this.buttonType == "V" then
           maps = pfDatabase:SearchVendor(param)
         --[[TODO: add extractor support and implement functions

--- a/browser.lua
+++ b/browser.lua
@@ -565,7 +565,7 @@ pfBrowser.input:SetScript("OnTextChanged", function()
   -- for each search type, get the matching IDs and add buttons for them
   for _, caption in ipairs({"Units","Objects","Items","Quests"}) do
     local searchType = strlower(caption)
-    local ids = pfDatabase:GenericSearch(text, searchType)
+    local ids = pfDatabase:BrowserSearch(text, searchType)
     local i = 0;
     local skip = false
     -- iterate the IDs and create/re-use buttons

--- a/browser.lua
+++ b/browser.lua
@@ -320,7 +320,7 @@ local function CreateResultEntry(i, resultType)
         local function StartAndFinish(startOrFinish, types)
           local strings = {["start"]="Started by ", ["end"]="Finished by "}
           for _, key in ipairs(types) do
-            if questData[startOrFinish][key] then
+            if questData[startOrFinish] and questData[startOrFinish][key] then
               local typeName = {["U"]="units",["O"]="objects",["I"]="items"}
               GameTooltip:AddLine("\n|cffffff00"..strings[startOrFinish]..typeName[key]..":|r")
               for _,id in ipairs(questData[startOrFinish][key]) do

--- a/browser.lua
+++ b/browser.lua
@@ -305,14 +305,36 @@ local function CreateResultEntry(i, resultType)
       GameTooltip:SetOwner(this.text, "ANCHOR_LEFT", -10, -5)
       GameTooltip:SetText(this.name, .3, 1, .8)
       local questTexts = pfDB[resultType]["loc"][this.id]
-      if questTexts["O"] then
-        GameTooltip:AddLine(questTexts["O"], 1,1,1,true)
+      local questData = pfDB[resultType]["data"][this.id]
+      GameTooltip:AddLine(" ")
+      if questData.lvl then
+        GameTooltip:AddDoubleLine("|cffffff00Quest Level: |r", questData.lvl, 1,1,1, 1,1,1)
       end
-      if questTexts["D"] and questTexts["O"] then
-        GameTooltip:AddLine("-", 0,0,0)
+      if questData.min then
+        GameTooltip:AddDoubleLine("|cffffff00Required Level: |r", questData.min, 1,1,1, 1,1,1)
       end
-      if questTexts["D"] then
-        GameTooltip:AddLine(ReplaceQuestDetailWildcards(questTexts["D"]), .6,1,.9,true)
+      if questData["start"] or questData["end"] then
+        local function StartAndFinish(startOrFinish, types)
+          local strings = {["start"]="Started by ", ["end"]="Finished by "}
+          for _, key in ipairs(types) do
+            if questData[startOrFinish][key] then
+              local typeName = {["U"]="units",["O"]="objects",["I"]="items"}
+              GameTooltip:AddLine("\n|cffffff00"..strings[startOrFinish]..typeName[key]..":|r")
+              for _,id in ipairs(questData[startOrFinish][key]) do
+                local name = pfDB[typeName[key]]["loc"][id] or id
+                GameTooltip:AddDoubleLine(" ", name, 0,0,0, 1,1,1)
+              end
+            end
+          end
+        end
+        StartAndFinish("start", {"U","O","I"})
+        StartAndFinish("end", {"U","O"})
+      end
+      if questTexts["O"] and questTexts["O"] ~= "" then
+        GameTooltip:AddLine("\n|cffffff00Objectives: |r"..ReplaceQuestDetailWildcards(questTexts["O"]), 1,1,1,true)
+      end
+      if questTexts["D"] and questTexts["D"] ~= "" then
+        GameTooltip:AddLine("\n|cffffff00Details: |r"..ReplaceQuestDetailWildcards(questTexts["D"]), .6,1,.9,true)
       end
       GameTooltip:Show()
     end)
@@ -335,7 +357,29 @@ local function CreateResultEntry(i, resultType)
       local name = this.name
       local maps = {}
       GameTooltip:SetOwner(this.text, "ANCHOR_LEFT", -10, -5)
-      GameTooltip:SetText("Located in", .3, 1, .8)
+      GameTooltip:SetText(name, .3, 1, .8)
+      if resultType == "units" then
+        local unitData = units[id]
+        if unitData.lvl then
+          GameTooltip:AddDoubleLine("|cffffff00Level:|r", unitData.lvl, 0,0,0, 1,1,1)
+        end
+        local reactionStringA = "|c00ff0000Hostile|r"
+        local reactionStringH = "|c00ff0000Hostile|r"
+        if unitData.fac then
+          if unitData.fac == "AH" then
+            reactionStringA = "|c0000ff00Friendly|r"
+            reactionStringH = "|c0000ff00Friendly|r"
+          elseif unitData.fac == "A" then
+            reactionStringA = "|c0000ff00Friendly|r"
+          elseif unitData.fac == "H" then
+            reactionStringH = "|c0000ff00Friendly|r"
+          end
+        end
+        GameTooltip:AddLine("|cffffff00Reactions:|r", 1,1,1)
+        GameTooltip:AddDoubleLine("Alliance", reactionStringA, 1,1,1, 0,0,0)
+        GameTooltip:AddDoubleLine("Horde", reactionStringH, 1,1,1, 0,0,0)
+      end
+      GameTooltip:AddLine("\n|cffffff00Located in:|r", 1,1,1)
       if pfDB[resultType]["data"][id] and pfDB[resultType]["data"][id]["coords"] then
         for _, data in pairs(pfDB[resultType]["data"][id]["coords"]) do
           local zone = data[3]

--- a/browser.lua
+++ b/browser.lua
@@ -123,7 +123,7 @@ local function CreateResultEntry(i, resultType)
       pfBrowser_fav[resultType][id] = nil
       this.icon:SetVertexColor(1,1,1,.1)
     else
-      pfBrowser_fav[resultType][id] = true
+      pfBrowser_fav[resultType][id] = this:GetParent().name
       this.icon:SetVertexColor(1,1,1,1)
     end
   end)

--- a/config.lua
+++ b/config.lua
@@ -14,6 +14,7 @@ pfQuest_defconfig = {
   ["showids"] = "0",
   ["worldmaptransp"] = "1.0",
   ["minimaptransp"] = "1.0",
+  ["mindropchance"] = "0",
 }
 
 local function LoadConfig()
@@ -94,7 +95,7 @@ end
 pfQuestConfig = CreateFrame("Frame", "pfQuestConfig", UIParent)
 pfQuestConfig:Hide()
 pfQuestConfig:SetWidth(280)
-pfQuestConfig:SetHeight(360)
+pfQuestConfig:SetHeight(385)
 pfQuestConfig:SetPoint("CENTER", 0, 0)
 pfQuestConfig:SetFrameStrata("TOOLTIP")
 pfQuestConfig:SetMovable(true)
@@ -146,6 +147,7 @@ pfQuestConfig:SetScript("OnEvent", function()
     CreateConfigEntry("showids",             "Show IDs",                       "checkbox")
     CreateConfigEntry("worldmaptransp",      "WorldMap Node Transparency",     "text")
     CreateConfigEntry("minimaptransp",       "MiniMap Node Transparency",      "text")
+    CreateConfigEntry("mindropchance",       "Minimum Drop Chance",            "text")
   end
 end)
 

--- a/config.lua
+++ b/config.lua
@@ -11,6 +11,7 @@ pfQuest_defconfig = {
   ["minimapnodes"] = "1", -- hide all minimap entries
   ["questlogbuttons"] = "1", -- shows buttons inside the questlog
   ["worldmapmenu"] = "1", -- shows the dropdown selection in worldmap
+  ["showids"] = "0",
   ["worldmaptransp"] = "1.0",
   ["minimaptransp"] = "1.0",
 }
@@ -93,7 +94,7 @@ end
 pfQuestConfig = CreateFrame("Frame", "pfQuestConfig", UIParent)
 pfQuestConfig:Hide()
 pfQuestConfig:SetWidth(280)
-pfQuestConfig:SetHeight(340)
+pfQuestConfig:SetHeight(360)
 pfQuestConfig:SetPoint("CENTER", 0, 0)
 pfQuestConfig:SetFrameStrata("TOOLTIP")
 pfQuestConfig:SetMovable(true)
@@ -142,6 +143,7 @@ pfQuestConfig:SetScript("OnEvent", function()
     CreateConfigEntry("minimapnodes",        "Show MiniMap Nodes",             "checkbox")
     CreateConfigEntry("questlogbuttons",     "Show QuestLog Buttons",          "checkbox")
     CreateConfigEntry("worldmapmenu",        "Show WorldMap Menu",             "checkbox")
+    CreateConfigEntry("showids",             "Show IDs",                       "checkbox")
     CreateConfigEntry("worldmaptransp",      "WorldMap Node Transparency",     "text")
     CreateConfigEntry("minimaptransp",       "MiniMap Node Transparency",      "text")
   end

--- a/database.lua
+++ b/database.lua
@@ -257,7 +257,7 @@ end
 -- Scans for all items with a specified ID
 -- Adds map nodes for each drop and vendor
 -- Returns its map table
-function pfDatabase:SearchItemID(id, meta, maps)
+function pfDatabase:SearchItemID(id, meta, maps, allowedTypes)
   if not items[id] then return maps end
 
   local maps = maps or {}
@@ -267,7 +267,7 @@ function pfDatabase:SearchItemID(id, meta, maps)
   meta["item"] = pfDB.items.loc[id]
 
   -- search unit drops
-  if items[id]["U"] then
+  if items[id]["U"] and ((not allowedTypes) or allowedTypes["U"]) then
     for unit, chance in pairs(items[id]["U"]) do
       meta["texture"] = nil
       meta["droprate"] = chance
@@ -277,7 +277,7 @@ function pfDatabase:SearchItemID(id, meta, maps)
   end
 
   -- search object loot (veins, chests, ..)
-  if items[id]["O"] then
+  if items[id]["O"] and ((not allowedTypes) or allowedTypes["O"]) then
     for object, chance in pairs(items[id]["O"]) do
       meta["texture"] = nil
       meta["droprate"] = chance
@@ -287,7 +287,7 @@ function pfDatabase:SearchItemID(id, meta, maps)
   end
 
   -- search vendor goods
-  if items[id]["V"] then
+  if items[id]["V"] and ((not allowedTypes) or allowedTypes["V"]) then
     for unit, chance in pairs(items[id]["V"]) do
       meta["texture"] = "Interface\\AddOns\\pfQuest\\img\\icon_vendor"
       meta["droprate"] = nil

--- a/database.lua
+++ b/database.lua
@@ -175,6 +175,7 @@ function pfDatabase:SearchMobID(id, meta, maps)
       -- add all gathered data
       meta = meta or {}
       meta["spawn"] = pfDB.units.loc[id]
+      meta["spawnid"] = id
 
       meta["title"] = meta["quest"] or meta["item"] or meta["spawn"]
       meta["zone"]  = zone
@@ -222,6 +223,7 @@ function pfDatabase:SearchObjectID(id, meta, maps)
       -- add all gathered data
       meta = meta or {}
       meta["spawn"] = pfDB.objects.loc[id]
+      meta["spawnid"] = id
 
       meta["title"] = meta["quest"] or meta["item"] or meta["spawn"]
       meta["zone"]  = zone

--- a/database.lua
+++ b/database.lua
@@ -677,7 +677,7 @@ end
 pfDatabase.lastSearchQuery = ""
 pfDatabase.lastSearchResults = {["items"] = {}, ["quests"] = {}, ["objects"] = {}, ["units"] = {}}
 
--- GenericSearch
+-- BrowserSearch
 -- Search for a list of IDs of the specified `searchType` based on if `query` is
 -- part of the name or ID of the database entry it is compared against.
 --
@@ -688,11 +688,11 @@ pfDatabase.lastSearchResults = {["items"] = {}, ["quests"] = {}, ["objects"] = {
 -- "units"
 --
 -- Returns a table and an integer, the latter being the element count of the
--- former. The table contains the ID as keys for the boolean value `true`.
--- E.g.: {{[5] = true, [231] = true}, 2}
+-- former. The table contains the ID as keys for the name of the search result.
+-- E.g.: {{[5] = "Some Name", [231] = "Another Name"}, 2}
 -- If the query doesn't satisfy the minimum search length requiered for its
 -- type (number/string), the favourites for the `searchType` are returned.
-function pfDatabase:GenericSearch(query, searchType)
+function pfDatabase:BrowserSearch(query, searchType)
   local queryLength = strlen(query) -- needed for some checks
   local queryNumber = tonumber(query) -- if nil, the query is NOT a number
   local results = {} -- save results

--- a/database.lua
+++ b/database.lua
@@ -110,14 +110,16 @@ end
 -- GetIDByName
 -- Scans localization tables for matching IDs
 -- Returns table with all IDs
-function pfDatabase:GetIDByName(name, db)
+function pfDatabase:GetIDByName(name, db, partial)
   if not pfDB[db] then return nil end
   local ret = {}
 
   for id, loc in pairs(pfDB[db]["loc"]) do
     if db == "quests" then loc = loc["T"] end
 
-    if loc and name and strfind(strlower(loc), strlower(name)) then
+    -- if the partial variable was passed, use strfind, otherwise compare the strings
+    if loc and name and ((partial and strfind(strlower(loc), strlower(name))) or strlower(loc) == strlower(name))
+    then
       ret[id] = loc
     end
   end
@@ -736,7 +738,7 @@ function pfDatabase:GenericSearch(query, searchType)
       if (queryNumber) then
         results = pfDatabase:GetIDByIDPart(query, searchType)
       else
-        results = pfDatabase:GetIDByName(query, searchType)
+        results = pfDatabase:GetIDByName(query, searchType, true)
       end
       local resultCount = 0
       for _,_ in pairs(results) do

--- a/database.lua
+++ b/database.lua
@@ -270,23 +270,30 @@ function pfDatabase:SearchItemID(id, meta, maps, allowedTypes)
   meta["itemid"] = id
   meta["item"] = pfDB.items.loc[id]
 
+  local minChance = tonumber(pfQuest_config.mindropchance)
+  if not minChance then minChance = 0 end
+
   -- search unit drops
   if items[id]["U"] and ((not allowedTypes) or allowedTypes["U"]) then
     for unit, chance in pairs(items[id]["U"]) do
-      meta["texture"] = nil
-      meta["droprate"] = chance
-      meta["sellcount"] = nil
-      maps = pfDatabase:SearchMobID(unit, meta, maps)
+      if chance >= minChance then
+        meta["texture"] = nil
+        meta["droprate"] = chance
+        meta["sellcount"] = nil
+        maps = pfDatabase:SearchMobID(unit, meta, maps)
+      end
     end
   end
 
   -- search object loot (veins, chests, ..)
   if items[id]["O"] and ((not allowedTypes) or allowedTypes["O"]) then
     for object, chance in pairs(items[id]["O"]) do
-      meta["texture"] = nil
-      meta["droprate"] = chance
-      meta["sellcount"] = nil
-      maps = pfDatabase:SearchObjectID(object, meta, maps)
+      if chance >= minChance and chance > 0 then
+        meta["texture"] = nil
+        meta["droprate"] = chance
+        meta["sellcount"] = nil
+        maps = pfDatabase:SearchObjectID(object, meta, maps)
+      end
     end
   end
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -2,52 +2,61 @@ config
 ======
 
 ## ["minimapbutton"]
-This option can be used to hide the pfQuest-minimap button.
+This option can be used to hide the pfQuest-minimap button.  
 Default=1
 
-## ["trackingmethod"] 
-The current method what quests should be automatically shown and tracked. Default=1
+## ["trackingmethod"]
+The current method what quests should be automatically shown and tracked.  
+Default=1
 1. Show All Quests
 2. Show Tracked Quests
 3. Manual Selection ("Show"-Button)
 4. Disable all Quests
 
 ## ["allquestgivers"]
-If selected, this option will query for all questgivers and shows them on the map. 
+If selected, this option will query for all questgivers and shows them on the map.  
 Default=1
 
 ## ["showlowlevel"]
-If `allquestgivers` is selected, this option can be used to hide low-level quests from the map. If set to `1`, then no filters are applied. 
+If `allquestgivers` is selected, this option can be used to hide low-level quests from the map. If set to `1`, then no filters are applied.  
 Default=1
 
+## ["showids"]
+If selected, the result buttons of the browser and the tooltips of nodes on the maps will show the ID of the unit/object/item/quest.  
+Default=0
+
 ## ["currentquestgivers"]
-If selected, the current quest-ender npcs/objects will be shown on the map for active quests. 
+If selected, the current quest-ender npcs/objects will be shown on the map for active quests.  
 Default=1
 
 ## ["minimapnodes"]
-If selected, minimap nodes will be shown. 
+If selected, minimap nodes will be shown.  
 Default=1
 
 ## ["questlogbuttons"]
-If selected, buttons will be shown in the questlog to show, clean and reset the nodes.
+If selected, buttons will be shown in the questlog to show, clean and reset the nodes.  
 Default=1
 
 ## ["worldmapmenu"]
-If selected, a dropdown menu will be shown on the worldmap to select the `trackingmethod`. 
+If selected, a dropdown menu will be shown on the worldmap to select the `trackingmethod`.  
 Default=1
 
 ## ["worldmaptransp"]
-This option represents the transparency of worldmap nodes. Can be values between 0.0 and 1.0
+This option represents the transparency of worldmap nodes. Can be values between 0.0 and 1.0  
 Default=1.0
 
 ## ["minimaptransp"]
-This option represents the transparency of minimap nodes. Can be values between 0.0 and 1.0
+This option represents the transparency of minimap nodes. Can be values between 0.0 and 1.0  
 Default=1.0
 
+## ["mindropchance"]
+This option defines the minimum drop chance a unit or object must have for an item, so that its node is displayed on the map. Can be values between 0.0 and 100.0. Values > 100 will show no drops at all.  
+Default=0
+
 ## ["worldmaptexture"]
-The default texture of worldmap nodes when no texture is set in the `meta`.
+The default texture of worldmap nodes when no texture is set in the `meta`.  
 Default="node1"
 
 ## ["minimaptexture"]
-The default texture of minimap nodes when no texture is set in the `meta`.
+The default texture of minimap nodes when no texture is set in the `meta`.  
 Default="node2"

--- a/docs/meta.md
+++ b/docs/meta.md
@@ -21,22 +21,26 @@ The y-axis of the node's position
 
 ## Set by Spawn/Object Queries
 ### ["spawn"]
-This defines the name of the spawn that should be shown and the title of the node. It gets replaced if either "item" or "quest" is set.
-The SearchMob and SearchObject function will use this to set the "title" of the node.
+This defines the name of the spawn that should be shown and the title of the node. It gets replaced if either `"item"` or `"quest"` is set.  
+The `SearchMob` and `SearchObject` function will use this to set the "title" of the node.
+
+### ["spawnid"]
+This defines the ID of the spawn that should be shown in the title of the node tooltip when the `showids` option is enabled.  
+The `pfMap:NodeEnter()` function will use this to set the "title" of the node.
 
 ### ["level"]
-Can be used to print a level for the created node this can either be a string with a number inside or a range like "16-18".
+Can be used to print a level for the created node this can either be a string with a number inside or a range like `"16-18"`.
 
 ### ["respawn"]
 This can be set to the respawn timer of the given object/unit.
 
 ### ["spawntype"]
-This should be set to the type the node is. Usually this is either "Unit" or "Object".
+This should be set to the type the node is. Usually this is either `"Unit"` or `"Object"`.
 
 ## Set by Item Queries
 ### ["item"]
-This defines the name of the item that should be shown and the title of the node. It gets replaced if "quest" is set.
-The SearchMob and SearchObject function will use this to set the "title" of the node.
+This defines the name of the item that should be shown and the title of the node. It gets replaced if "quest" is set.  
+The `SearchMob` and `SearchObject` function will use this to set the "title" of the node.
 
 ### ["itemid"]
 If the node displays an item, this value can be set to the corresponding itemid to make further working with the node easier.
@@ -48,7 +52,7 @@ This is not set directly. This can be set to the generated itemlink built with t
 If the item is dropped or looted from any object or unit, this can represent the dropchance.
 
 ### ["sellcount"]
-This is used for entries from within the vendor table of the item database to represent the number of items one vendor has. If set to "0" its equal to infinite.
+This is used for entries from within the vendor table of the item database to represent the number of items one vendor has. If set to `0` its equal to infinite.
 
 ## Set by Quest Queries
 ### ["qlvl"]
@@ -58,15 +62,15 @@ The quests minimal level to accept the quest.
 The quests display level, usually the recommended level by the questlog.
 
 ### ["quest"]
-This defines the name of the quest that should be shown and the title of the node. If quest is set, neither spawn nor item will be used as title.
-The SearchMob and SearchObject function will use this to set the "title" of the node.
+This defines the name of the quest that should be shown and the title of the node. If quest is set, neither spawn nor item will be used as title.  
+The `SearchMob` and `SearchObject` function will use this to set the "title" of the node.
 
 ## Display Related
 ### ["texture"]
-If no texture is set, the map function will use its default node icon. Otherwise this can be so vendor, quest or custom symbols. The value should be a path to an exising image file. ( e.g: "Interface\\AddOns\\pfQuest\\img\\icon_vendor" )
+If no texture is set, the map function will use its default node icon. Otherwise this can be so vendor, quest or custom symbols. The value should be a path to an exising image file. ( e.g: `Interface\\AddOns\\pfQuest\\img\\icon_vendor` )
 
 ### ["vertex"]
-This can be used to tint textures with a given color. The value is a table with RGB colors. ( e.g: "{ 1, .8, .4 }" )
+This can be used to tint textures with a given color. The value is a table with RGB colors. ( e.g: `{ 1, .8, .4 }` )
 
 ### ["layer"]
 [DEPRECATED: The layer is now auto-generated to a value based on its texture]
@@ -77,12 +81,11 @@ The layer can be used to force a position above or below other nodes. Multiple n
 Those values are not reliable to read after the function calls. Those are used to request special behaviours of one of the DB-query functions.
 
 ### ["qlogid"]
-Represents the quests current position in the players questlog. This is used to gather extended data, like current progress of the quest, which will be written into `qstate`. If this is set, the SearchQuest and SearchQuestByID functions will also behave in a way as the pfQuest tracker needs it:
+Represents the quests current position in the players questlog. This is used to gather extended data, like current progress of the quest, which will be written into `qstate`. If this is set, the `SearchQuest` and `SearchQuestByID` functions will also behave in a way as the pfQuest tracker needs it:
   * It does not show the quest-starters
   * It uses grey question marks for incompleted quests
   * It uses yellow question marks for completed quests
   * It will skip already finished objectives
 
 ### ["qstate"]
-This reflects the current state of the quest in the questlog, can be strings like "done" or "progress".
-
+This reflects the current state of the quest in the questlog, can be strings like `"done"` or `"progress"`.

--- a/map.lua
+++ b/map.lua
@@ -473,8 +473,7 @@ end
 function pfMap:NodeEnter()
   local tooltip = this:GetParent() == WorldMapButton and WorldMapTooltip or GameTooltip
   tooltip:SetOwner(this, ANCHOR_BOTTOMLEFT)
-  tooltip:SetText(this.spawn, .3, 1, .8)
-
+  tooltip:SetText(this.spawn..(pfQuest_config.showids == "1" and " |cffcccccc("..this.spawnid..")|r" or ""), .3, 1, .8)
   tooltip:AddDoubleLine("Level:", (this.level or UNKNOWN), .8,.8,.8, 1,1,1)
   tooltip:AddDoubleLine("Type:", (this.spawntype or UNKNOWN), .8,.8,.8, 1,1,1)
   tooltip:AddDoubleLine("Respawn:", (this.respawn or UNKNOWN), .8,.8,.8, 1,1,1)
@@ -513,6 +512,7 @@ function pfMap:UpdateNode(frame, node)
       -- and add core information
       frame.layer     = tab.layer
       frame.spawn     = tab.spawn
+      frame.spawnid   = tab.spawnid
       frame.spawntype = tab.spawntype
       frame.respawn   = tab.respawn
       frame.level     = tab.level


### PR DESCRIPTION
* Browser:
    * Fix OnClick functions
    * More info on tooltips
    * ID on result buttons (if config enabled) and tooltips (always)
    * Fav table saves names instead of boolean
* Database:
    * `BrowserSearch` uses existing search functions
    * `GetIDByName` allows search for partial match if third parameter is passed to it
* Map:
    * Add unit/object ID to node tooltips (if config enabled)
    * Add config option `mindropchance` and only show nodes if they have a higher chance.