### PR TITLE
show only related nodes on mouseover

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -90,25 +90,30 @@ pfQuest_defconfig = {
     text = pfQuest_Loc["Unified Quest Location Markers"],
     default = "1", type = "checkbox", pos = { 2, 2 },
   },
+  ["showrelatednodes"] = { -- Show only nodes that have a relation to mouseover node
+    text = pfQuest_Loc["Show Only Related Nodes On Mouseover"],
+    default = "0", type = "checkbox", pos = { 2, 3 },
+  },
+ 
   ["allquestgivers"] = { -- Display Available Quest Givers
     text = pfQuest_Loc["Display Available Quest Givers"],
-    default = "1", type = "checkbox", pos = { 2, 3 },
+    default = "1", type = "checkbox", pos = { 2, 4 },
   },
   ["currentquestgivers"] = { -- Display Current Quest Givers
     text = pfQuest_Loc["Display Current Quest Givers"],
-    default = "1", type = "checkbox", pos = { 2, 4 },
+    default = "1", type = "checkbox", pos = { 2, 5 },
   },
   ["showlowlevel"] = { -- Display Low Level Quest Givers
     text = pfQuest_Loc["Display Low Level Quest Givers"],
-    default = "0", type = "checkbox", pos = { 2, 5 },
+    default = "0", type = "checkbox", pos = { 2, 6 },
   },
   ["showhighlevel"] = { -- Display Level+3 Questgivers
     text = pfQuest_Loc["Display Level+3 Quest Givers"],
-    default = "1", type = "checkbox", pos = { 2, 6 },
+    default = "1", type = "checkbox", pos = { 2, 7 },
   },
   ["showfestival"] = { -- Display Event & Daily Quests
     text = pfQuest_Loc["Display Event & Daily Quests"],
-    default = "0", type = "checkbox", pos = { 2, 7 },
+    default = "0", type = "checkbox", pos = { 2, 8 },
   },
 
   ["_Routes_"] = {

--- a/map.lua
+++ b/map.lua
@@ -858,8 +858,11 @@ pfMap:SetScript("OnUpdate", function()
         -- zoom node
         transition = frame:Animate((frame.texture and 28 or frame.defsize), 1) or transition
       elseif not highlight and pfMap.highlight then
-        -- fade node
-        transition = frame:Animate(frame.defsize, .3) or transition
+        if pfQuest_config["showrelatednodes"] == "1" then
+          transition = frame:Animate(frame.defsize, 0.0) or transition
+        else 
+          transition = frame:Animate(frame.defsize, 0.3) or transition
+        end
       elseif frame.texture then
         -- defaults for textured nodes
         transition = frame:Animate(frame.defsize, 1) or transition


### PR DESCRIPTION
hides any nodes not related to currently mouseover node by adding additional if statement to `not highlight and pfMap.highlight then` checking `if pfQuest_config["showrelatednodes"] == "1" `