### PR TITLE
Add ctrl key tip text to config

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -11,7 +11,6 @@ pfQuest_defconfig = {
     -- 1: All Quests; 2: Tracked; 3: Manual; 4: Hide
     text = nil, default = 1, type = nil, pos = nil,
   },
-
   ["_General_"] = {
     text = pfQuest_Loc["General"],
     default = nil, type = "header", pos = { 1, 1 },
@@ -48,14 +47,17 @@ pfQuest_defconfig = {
     text = pfQuest_Loc["Minimum Item Drop Chance"],
     default = "1", type = "text", pos = { 1, 9 },
   },
-
   ["_Map & Minimap_"] = {
     text = pfQuest_Loc["Map & Minimap"],
-    default = nil, type = "header", pos = { 1, 11 },
+    default = nil, type = "header", pos = { 1, 10 },
   },
   ["minimapnodes"] = { -- Enable Minimap Nodes
     text = pfQuest_Loc["Enable Minimap Nodes"],
-    default = "1", type = "checkbox", pos = { 1, 12 },
+    default = "1", type = "checkbox", pos = { 1, 11 },
+  },
+  ["minimaptip"] = {
+    text = pfQuest_Loc["Info: Press Control To Hide Nodes On Mouseover"],
+    default = "1",  type = "normal", pos = { 1, 12 },
   },
   ["cutoutminimap"] = { -- Use Cut-Out Minimap Node Icons
     text = pfQuest_Loc["Use Cut-Out Minimap Node Icons"],
@@ -90,50 +92,59 @@ pfQuest_defconfig = {
     text = pfQuest_Loc["Unified Quest Location Markers"],
     default = "1", type = "checkbox", pos = { 2, 2 },
   },
+  ["clustertip"] = {
+    text = pfQuest_Loc["Info: Press Control To Hide Markers On Mouseover"],
+    default = "1",  type = "normal", pos = { 2, 3 },
+  },
+  ["showrelatednodes"] = { -- Show only nodes that have a relation to mouseover node
+    text = pfQuest_Loc["Show Only Related Nodes On Mouseover"],
+    default = "0", type = "checkbox", pos = { 2, 4 },
+  },
+ 
   ["allquestgivers"] = { -- Display Available Quest Givers
     text = pfQuest_Loc["Display Available Quest Givers"],
-    default = "1", type = "checkbox", pos = { 2, 3 },
+    default = "1", type = "checkbox", pos = { 2, 5 },
   },
   ["currentquestgivers"] = { -- Display Current Quest Givers
     text = pfQuest_Loc["Display Current Quest Givers"],
-    default = "1", type = "checkbox", pos = { 2, 4 },
+    default = "1", type = "checkbox", pos = { 2, 6 },
   },
   ["showlowlevel"] = { -- Display Low Level Quest Givers
     text = pfQuest_Loc["Display Low Level Quest Givers"],
-    default = "0", type = "checkbox", pos = { 2, 5 },
+    default = "0", type = "checkbox", pos = { 2, 7 },
   },
   ["showhighlevel"] = { -- Display Level+3 Questgivers
     text = pfQuest_Loc["Display Level+3 Quest Givers"],
-    default = "1", type = "checkbox", pos = { 2, 6 },
+    default = "1", type = "checkbox", pos = { 2, 8 },
   },
   ["showfestival"] = { -- Display Event & Daily Quests
     text = pfQuest_Loc["Display Event & Daily Quests"],
-    default = "0", type = "checkbox", pos = { 2, 7 },
+    default = "0", type = "checkbox", pos = { 2, 9 },
   },
 
   ["_Routes_"] = {
     text = pfQuest_Loc["Routes"],
-    default = nil, type = "header", pos = { 2, 9 },
+    default = nil, type = "header", pos = { 2, 10 },
   },
   ["routes"] = { -- Show Route Between Objects
     text = pfQuest_Loc["Show Route Between Objects"],
-    default = "1", type = "checkbox", pos = { 2, 10 },
+    default = "1", type = "checkbox", pos = { 2, 11 },
   },
   ["routecluster"] = { -- Include Unified Quest Locations
     text = pfQuest_Loc["Include Unified Quest Locations"],
-    default = "1", type = "checkbox", pos = { 2, 11 },
+    default = "1", type = "checkbox", pos = { 2, 12 },
   },
   ["routeender"] = { -- Include Quest Enders
     text = pfQuest_Loc["Include Quest Enders"],
-    default = "1", type = "checkbox", pos = { 2, 12 },
+    default = "1", type = "checkbox", pos = { 2, 13 },
   },
   ["routestarter"] = { -- Include Quest Starters
     text = pfQuest_Loc["Include Quest Starters"],
-    default = "0", type = "checkbox", pos = { 2, 13 },
+    default = "0", type = "checkbox", pos = { 2, 14 },
   },
   ["arrow"] = { -- Show Arrow Along Routes
     text = pfQuest_Loc["Show Arrow Along Routes"],
-    default = "1", type = "checkbox", pos = { 2, 14 },
+    default = "1", type = "checkbox", pos = { 2, 15 },
   },
 
   ["_User Data_"] = {
@@ -320,7 +331,12 @@ function pfQuestConfig:CreateConfigEntries(config)
         frame.caption:SetPoint("LEFT", 10, 0)
         frame.caption:SetTextColor(.3,1,.8)
         frame.caption:SetFont(pfUI.font_default, pfUI_config.global.font_size+2, "OUTLINE")
-
+        
+       elseif data.type == "normal" then
+        frame.caption:SetPoint("LEFT", 20, 0)
+        frame.caption:SetTextColor(.3,1,.8)
+        frame.caption:SetFont(pfUI.font_default, pfUI_config.global.font_size-2, "OUTLINE")
+      
       -- checkbox
       elseif data.type == "checkbox" then
         frame.input = CreateFrame("CheckButton", nil, frame, "UICheckButtonTemplate")

--- a/config.lua
+++ b/config.lua
@@ -56,8 +56,13 @@ pfQuest_defconfig = {
     default = "1", type = "checkbox", pos = { 1, 11 },
   },
   ["minimaptip"] = {
+<<<<<<< Updated upstream
     text = pfQuest_Loc["Info: Press Control To Hide Nodes On Mouseover"],
     default = "1",  type = "normal", pos = { 1, 12 },
+=======
+    text = pfQuest_Loc["Tip: Press Control To Hide Nodes On Mouseover"],
+    default = "1",  type = "tip", pos = { 1, 12 },
+>>>>>>> Stashed changes
   },
   ["cutoutminimap"] = { -- Use Cut-Out Minimap Node Icons
     text = pfQuest_Loc["Use Cut-Out Minimap Node Icons"],
@@ -93,8 +98,13 @@ pfQuest_defconfig = {
     default = "1", type = "checkbox", pos = { 2, 2 },
   },
   ["clustertip"] = {
+<<<<<<< Updated upstream
     text = pfQuest_Loc["Info: Press Control To Hide Markers On Mouseover"],
     default = "1",  type = "normal", pos = { 2, 3 },
+=======
+    text = pfQuest_Loc["Tip: Press Control To Hide Markers On Mouseover"],
+    default = "1",  type = "tip", pos = { 2, 3 },
+>>>>>>> Stashed changes
   },
   ["showrelatednodes"] = { -- Show only nodes that have a relation to mouseover node
     text = pfQuest_Loc["Show Only Related Nodes On Mouseover"],
@@ -332,7 +342,11 @@ function pfQuestConfig:CreateConfigEntries(config)
         frame.caption:SetTextColor(.3,1,.8)
         frame.caption:SetFont(pfUI.font_default, pfUI_config.global.font_size+2, "OUTLINE")
         
+<<<<<<< Updated upstream
        elseif data.type == "normal" then
+=======
+       elseif data.type == "tip" then
+>>>>>>> Stashed changes
         frame.caption:SetPoint("LEFT", 20, 0)
         frame.caption:SetTextColor(.3,1,.8)
         frame.caption:SetFont(pfUI.font_default, pfUI_config.global.font_size-2, "OUTLINE")

--- a/config.lua
+++ b/config.lua
@@ -56,13 +56,8 @@ pfQuest_defconfig = {
     default = "1", type = "checkbox", pos = { 1, 11 },
   },
   ["minimaptip"] = {
-<<<<<<< Updated upstream
-    text = pfQuest_Loc["Info: Press Control To Hide Nodes On Mouseover"],
-    default = "1",  type = "normal", pos = { 1, 12 },
-=======
     text = pfQuest_Loc["Tip: Press Control To Hide Nodes On Mouseover"],
     default = "1",  type = "tip", pos = { 1, 12 },
->>>>>>> Stashed changes
   },
   ["cutoutminimap"] = { -- Use Cut-Out Minimap Node Icons
     text = pfQuest_Loc["Use Cut-Out Minimap Node Icons"],
@@ -98,13 +93,8 @@ pfQuest_defconfig = {
     default = "1", type = "checkbox", pos = { 2, 2 },
   },
   ["clustertip"] = {
-<<<<<<< Updated upstream
-    text = pfQuest_Loc["Info: Press Control To Hide Markers On Mouseover"],
-    default = "1",  type = "normal", pos = { 2, 3 },
-=======
     text = pfQuest_Loc["Tip: Press Control To Hide Markers On Mouseover"],
     default = "1",  type = "tip", pos = { 2, 3 },
->>>>>>> Stashed changes
   },
   ["showrelatednodes"] = { -- Show only nodes that have a relation to mouseover node
     text = pfQuest_Loc["Show Only Related Nodes On Mouseover"],
@@ -342,11 +332,7 @@ function pfQuestConfig:CreateConfigEntries(config)
         frame.caption:SetTextColor(.3,1,.8)
         frame.caption:SetFont(pfUI.font_default, pfUI_config.global.font_size+2, "OUTLINE")
         
-<<<<<<< Updated upstream
-       elseif data.type == "normal" then
-=======
        elseif data.type == "tip" then
->>>>>>> Stashed changes
         frame.caption:SetPoint("LEFT", 20, 0)
         frame.caption:SetTextColor(.3,1,.8)
         frame.caption:SetFont(pfUI.font_default, pfUI_config.global.font_size-2, "OUTLINE")

--- a/map.lua
+++ b/map.lua
@@ -858,8 +858,11 @@ pfMap:SetScript("OnUpdate", function()
         -- zoom node
         transition = frame:Animate((frame.texture and 28 or frame.defsize), 1) or transition
       elseif not highlight and pfMap.highlight then
-        -- fade node
-        transition = frame:Animate(frame.defsize, .3) or transition
+        if pfQuest_config["showrelatednodes"] == "1" then
+          transition = frame:Animate(frame.defsize, 0.0) or transition
+        else 
+          transition = frame:Animate(frame.defsize, 0.3) or transition
+        end
       elseif frame.texture then
         -- defaults for textured nodes
         transition = frame:Animate(frame.defsize, 1) or transition

--- a/map.lua
+++ b/map.lua
@@ -723,7 +723,7 @@ function pfMap:UpdateMinimap()
     return
   end
 
-  -- hide all minimap nodes while shift is pressed
+  -- hide all minimap nodes while control is pressed
   if IsControlKeyDown() and MouseIsOver(pfMap.drawlayer) then
     this.xPlayer = nil
 

--- a/slashcmd.lua
+++ b/slashcmd.lua
@@ -20,6 +20,7 @@ SlashCmdList["PFDB"] = function(input, editbox)
     DEFAULT_CHAT_FRAME:AddMessage("|cff33ffcc/db|cffffffff quest <questname> |cffcccccc - " .. pfQuest_Loc["Show specific quest"])
     DEFAULT_CHAT_FRAME:AddMessage("|cff33ffcc/db|cffffffff quests |cffcccccc - " .. pfQuest_Loc["Show all quests on map"])
     DEFAULT_CHAT_FRAME:AddMessage("|cff33ffcc/db|cffffffff clean |cffcccccc - " .. pfQuest_Loc["Clean Map"])
+    DEFAULT_CHAT_FRAME:AddMessage("|cff33ffcc/db|cffffffff reset |cffcccccc - " .. pfQuest_Loc["Reset Map"])
     DEFAULT_CHAT_FRAME:AddMessage("|cff33ffcc/db|cffffffff chests |cffcccccc - " .. pfQuest_Loc["Show all chests on map"])
     DEFAULT_CHAT_FRAME:AddMessage("|cff33ffcc/db|cffffffff taxi [faction]|cffcccccc - " .. pfQuest_Loc["Show all taxi nodes of [faction]"])
     DEFAULT_CHAT_FRAME:AddMessage("|cff33ffcc/db|cffffffff rares [min, [max]]|cffcccccc - " .. pfQuest_Loc["Show all rare mobs of Level [min] to [max]"])
@@ -136,6 +137,12 @@ SlashCmdList["PFDB"] = function(input, editbox)
   if (arg1 == "clean") then
     pfMap:DeleteNode("PFDB")
     pfMap:UpdateNodes()
+    return
+  end
+  
+  -- argument: reset
+  if (arg1 == "reset") then
+   pfQuest:ResetAll()
     return
   end
 


### PR DESCRIPTION
adding tip text type
adding tip text for control key for hiding nodes and clusters on mouseover
fixing typo in maps.lua from shift -> control