### PR TITLE
Restore the original behavior of itemref

### DIFF
--- a/compat/client.lua
+++ b/compat/client.lua
@@ -21,17 +21,31 @@ pfQuestCompat.GetQuestLogTitle = function(id)
 end
 
 pfQuestCompat.InsertQuestLink = function(questid, name)
-  local questid = questid or 0
-  local fallback = name or UNKNOWN
-  local level = pfDB["quests"]["data"][questid] and pfDB["quests"]["data"][questid]["lvl"] or 0
-  ChatFrameEditBox:Show()
-
-  local name = pfDB["quests"]["loc"][questid] and pfDB["quests"]["loc"][questid]["T"] or fallback
-  if pfQuest_config["questlinks"] == "1" then
-    ChatFrameEditBox:Insert("|cffffff00|Hquest:" .. questid .. ":" .. level .. "|h[" .. name .. "]|h|r")
+  local link = ""
+  if string.find(questid, "quest") then -- if first arg is quest link (forward links from the chat)
+    if pfQuest_config["questlinks"] == "1" then
+      link = questid
+    else
+      _, _, link = string.find(questid, ".*|h%[(.*)%]|h.*")
+      link = "[" .. link .. "]"
+    end
   else
-    ChatFrameEditBox:Insert("[" .. name .. "]")
+    local fallback = name or UNKNOWN
+    local name = pfDB["quests"]["loc"][questid] and pfDB["quests"]["loc"][questid]["T"] or fallback
+    if pfQuest_config["questlinks"] == "1" then
+      local questid = questid or 0
+      local level = pfDB["quests"]["data"][questid] and pfDB["quests"]["data"][questid]["lvl"] or 0
+      link = "|cffffff00|Hquest:" .. questid .. ":" .. level .. "|h[" .. name .. "]|h|r"
+    else
+      link = "[" .. name .. "]"
+    end
   end
+
+  if not ChatFrameEditBox:IsVisible() then
+    ChatFrameEditBox:Show()
+  end
+
+  ChatFrameEditBox:Insert(link)
 end
 
 -- do the best to detect the minimap arrow on vanilla and tbc

--- a/quest.lua
+++ b/quest.lua
@@ -441,6 +441,11 @@ if not GetQuestLink then -- Allow to send questlinks from questlog
   -- Patch ItemRef to display Questlinks
   local pfQuestHookSetItemRef = SetItemRef
   SetItemRef = function(link, text, button)
+    -- enable the ability to forward links from the chat
+    if IsShiftKeyDown() and ChatFrameEditBox:IsVisible() then
+      return pfQuestCompat.InsertQuestLink(text)
+    end
+
     local isQuest, _, id    = string.find(link, "quest:(%d+):.*")
     local isQuest2, _, _   = string.find(link, "quest2:.*")
 

--- a/quest.lua
+++ b/quest.lua
@@ -450,10 +450,12 @@ if not GetQuestLink then -- Allow to send questlinks from questlog
     local isQuest2, _, _   = string.find(link, "quest2:.*")
 
     if isQuest or isQuest2 then
-      ShowUIPanel(ItemRefTooltip)
-      ItemRefTooltip:SetOwner(UIParent, "ANCHOR_PRESERVE")
-
       local hasTitle, _, questTitle = string.find(text, ".*|h%[(.*)%]|h.*")
+
+      if ItemRefTooltip:IsShown() and ItemRefTooltipTextLeft1:GetText() == questTitle then
+        return HideUIPanel(ItemRefTooltip)
+      end
+      ItemRefTooltip:SetOwner(UIParent, "ANCHOR_PRESERVE")
 
       id = tonumber(id)
 
@@ -522,7 +524,7 @@ if not GetQuestLink then -- Allow to send questlinks from questlog
         end
       end
 
-      ItemRefTooltip:Show()
+      ShowUIPanel(ItemRefTooltip)
     else
       pfQuestHookSetItemRef(link, text, button)
     end

--- a/quest.lua
+++ b/quest.lua
@@ -450,11 +450,13 @@ if not GetQuestLink then -- Allow to send questlinks from questlog
     local isQuest2, _, _   = string.find(link, "quest2:.*")
 
     if isQuest or isQuest2 then
-      local hasTitle, _, questTitle = string.find(text, ".*|h%[(.*)%]|h.*")
-
-      if ItemRefTooltip:IsShown() and ItemRefTooltipTextLeft1:GetText() == questTitle then
+      if ItemRefTooltip:IsShown() and ItemRefTooltip.questID and ItemRefTooltip.questID == id then
         return HideUIPanel(ItemRefTooltip)
       end
+
+      ItemRefTooltip.questID = id
+      local hasTitle, _, questTitle = string.find(text, ".*|h%[(.*)%]|h.*")
+
       ItemRefTooltip:SetOwner(UIParent, "ANCHOR_PRESERVE")
 
       id = tonumber(id)


### PR DESCRIPTION
This PR restores the original behavior (forward links from chat, toggle itemref) of itemref containing quest links