### PR TITLE
Fix extended tooltip issue with custom quests

### DIFF
--- a/database.lua
+++ b/database.lua
@@ -366,58 +366,72 @@ function pfDatabase:ShowExtendedTooltip(id, tooltip, parent, anchor, offx, offy)
   local locales = pfDB["quests"]["loc"][id]
   local data = pfDB["quests"]["data"][id]
 
-  tooltip:SetText((locales["T"] or UNKNOWN), .3, 1, .8)
-  tooltip:AddLine(" ")
+  if locales then
+    tooltip:SetText((locales["T"] or UNKNOWN), .3, 1, .8)
+    tooltip:AddLine(" ")
+  else
+    tooltip:SetText(UNKNOWN, .3, 1, .8)
+  end
 
-  -- quest start
-  for key, db in pairs({["U"]="units", ["O"]="objects", ["I"]="items"}) do
-    if data["start"] and data["start"][key] then
-      local entries = ""
-      for _, id in pairs(data["start"][key]) do
-        entries = entries .. (entries == "" and "" or ", ") .. ( pfDB[db]["loc"][id] or UNKNOWN )
+  if data then
+    -- quest start
+    if data["start"] then
+      for key, db in pairs({["U"]="units", ["O"]="objects", ["I"]="items"}) do
+        if data["start"][key] then
+          local entries = ""
+          for _, id in pairs(data["start"][key]) do
+            entries = entries .. (entries == "" and "" or ", ") .. ( pfDB[db]["loc"][id] or UNKNOWN )
+          end
+
+          tooltip:AddDoubleLine(pfQuest_Loc["Quest Start"]..":", entries, 1,1,1, 1,1,.8)
+        end
       end
+    end
 
-      tooltip:AddDoubleLine(pfQuest_Loc["Quest Start"]..":", entries, 1,1,1, 1,1,.8)
+    -- quest end
+    if data["end"] then
+      for key, db in pairs({["U"]="units", ["O"]="objects"}) do
+        if data["end"][key] then
+          local entries = ""
+          for _, id in ipairs(data["end"][key]) do
+            entries = entries .. (entries == "" and "" or ", ") .. ( pfDB[db]["loc"][id] or UNKNOWN )
+          end
+
+          tooltip:AddDoubleLine(pfQuest_Loc["Quest End"]..":", entries, 1,1,1, 1,1,.8)
+        end
+      end
     end
   end
 
-  -- quest end
-  for key, db in pairs({["U"]="units", ["O"]="objects"}) do
-    if data["end"] and data["end"][key] then
-      local entries = ""
-      for _, id in ipairs(data["end"][key]) do
-        entries = entries .. (entries == "" and "" or ", ") .. ( pfDB[db]["loc"][id] or UNKNOWN )
-      end
-
-      tooltip:AddDoubleLine(pfQuest_Loc["Quest End"]..":", entries, 1,1,1, 1,1,.8)
+  if locales then
+    -- obectives
+    if locales["O"] and locales["O"] ~= "" then
+      tooltip:AddLine(" ")
+      tooltip:AddLine(pfDatabase:FormatQuestText(locales["O"]),1,1,1,true)
     end
-  end
 
-  -- obectives
-  if locales["O"] and locales["O"] ~= "" then
-    tooltip:AddLine(" ")
-    tooltip:AddLine(pfDatabase:FormatQuestText(locales["O"]),1,1,1,true)
-  end
-
-  -- details
-  if locales["D"] and locales["D"] ~= "" then
-    tooltip:AddLine(" ")
-    tooltip:AddLine(pfDatabase:FormatQuestText(locales["D"]),.6,.6,.6,true)
+    -- details
+    if locales["D"] and locales["D"] ~= "" then
+      tooltip:AddLine(" ")
+      tooltip:AddLine(pfDatabase:FormatQuestText(locales["D"]),.6,.6,.6,true)
+    end
   end
 
   -- add levels
-  if data.lvl or data.min then
-    tooltip:AddLine(" ")
-  end
-  if data.lvl then
-    local questlevel = tonumber(data.lvl)
-    local color = GetDifficultyColor(questlevel)
-    tooltip:AddLine("|cffffffff" .. pfQuest_Loc["Quest Level"] .. ": |r" .. questlevel, color.r, color.g, color.b)
-  end
-  if data.min then
-    local questlevel = tonumber(data.min)
-    local color = GetDifficultyColor(questlevel)
-    tooltip:AddLine("|cffffffff" .. pfQuest_Loc["Required Level"] .. ": |r" .. questlevel, color.r, color.g, color.b)
+  if data then
+    if data["lvl"] or data["min"] then
+      tooltip:AddLine(" ")
+    end
+    if data["lvl"] then
+      local questlevel = tonumber(data["lvl"])
+      local color = GetDifficultyColor(questlevel)
+      tooltip:AddLine("|cffffffff" .. pfQuest_Loc["Quest Level"] .. ": |r" .. questlevel, color.r, color.g, color.b)
+    end
+    if data["min"] then
+      local questlevel = tonumber(data["min"])
+      local color = GetDifficultyColor(questlevel)
+      tooltip:AddLine("|cffffffff" .. pfQuest_Loc["Required Level"] .. ": |r" .. questlevel, color.r, color.g, color.b)
+    end
   end
 
   tooltip:Show()


### PR DESCRIPTION
This should fix an error when viewing unknown complete quests on a server like Turtle WoW. Unknown quests do disappear on a reload. Possibly should somehow properly log/query unknown quests in the future?