### PR TITLE
Fix incorrect display of quest text

### DIFF
--- a/database.lua
+++ b/database.lua
@@ -1379,7 +1379,7 @@ function pfDatabase:FormatQuestText(questText)
   questText = string.gsub(questText, "$[Bb]", "\n")
   -- UnitSex("player") returns 2 for male and 3 for female
   -- that's why there is an unused capture group around the $[Gg]
-  return string.gsub(questText, "($[Gg])(.+):(.+);", "%"..UnitSex("player"))
+  return string.gsub(questText, "($[Gg])([^:]+):([^;]+);", "%"..UnitSex("player"))
 end
 
 -- GetQuestIDs


### PR DESCRIPTION
Old pattern is greedy.
![1](https://user-images.githubusercontent.com/5354378/201944448-eac20bee-8326-4be3-94f0-04e5b19dc049.jpg)
