### PR TITLE
Fix: translated text does not fit vertically

### DIFF
--- a/database.lua
+++ b/database.lua
@@ -1379,7 +1379,7 @@ function pfDatabase:FormatQuestText(questText)
   questText = string.gsub(questText, "$[Bb]", "\n")
   -- UnitSex("player") returns 2 for male and 3 for female
   -- that's why there is an unused capture group around the $[Gg]
-  return string.gsub(questText, "($[Gg])(.+):(.+);", "%"..UnitSex("player"))
+  return string.gsub(questText, "($[Gg])([^:]+):([^;]+);", "%"..UnitSex("player"))
 end
 
 -- GetQuestIDs

--- a/quest.lua
+++ b/quest.lua
@@ -420,9 +420,11 @@ function pfQuest:AddQuestLogIntegration()
       local QuestLogQuestTitle = EQL3_QuestLogQuestTitle or QuestLogQuestTitle
       local QuestLogObjectivesText = EQL3_QuestLogObjectivesText or QuestLogObjectivesText
       local QuestLogQuestDescription = EQL3_QuestLogQuestDescription or QuestLogQuestDescription
+      local QuestLogDetailScrollFrame = EQL3_QuestLogDetailScrollFrame or QuestLogDetailScrollFrame
       QuestLogQuestTitle:SetText(pfDatabase:FormatQuestText(pfDB["quests"][lang][id]["T"]))
       QuestLogObjectivesText:SetText(pfDatabase:FormatQuestText(pfDB["quests"][lang][id]["O"]))
       QuestLogQuestDescription:SetText(pfDatabase:FormatQuestText(pfDB["quests"][lang][id]["D"]))
+      QuestLogDetailScrollFrame:UpdateScrollChildRect()
     end
   end)
 


### PR DESCRIPTION
![1](https://user-images.githubusercontent.com/5354378/202180122-5283d71a-0426-479c-96d4-cf1af6d5ea30.png)

Fix for WoW Vanilla. Maybe not needed for TBC.