### PR TITLE
Use the game's `ToggleWorldMap()` to open the map

### DIFF
--- a/map.lua
+++ b/map.lua
@@ -399,7 +399,9 @@ end
 
 function pfMap:ShowMapID(map)
   if map then
-    WorldMapFrame:Show()
+    if not WorldMapFrame:IsShown() then
+      ToggleWorldMap()
+    end
     pfMap:SetMapByID(map)
     pfMap:UpdateNodes()
     return true

--- a/tracker.lua
+++ b/tracker.lua
@@ -269,7 +269,7 @@ function tracker.ButtonClick()
     pfQuest.updateQuestGivers = true
   elseif IsControlKeyDown() and not WorldMapFrame:IsShown() then
     -- show world map
-    WorldMapFrame:Show()
+    ToggleWorldMap()
   elseif IsControlKeyDown() and pfQuest_config["spawncolors"] == "0" then
     -- switch color
     pfQuest_colors[this.title] = { pfMap.str2rgb(this.title .. GetTime()) }


### PR DESCRIPTION
Small change to use the game's `ToggleWorldMap()` to open the map instead of `WorldMapFrame:Show()`. This ensures that the UI's layout handling code runs, allowing players to close the map with the escape key.