### PR TITLE
Add pfQuestConfig:ResetConfigFrames

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -440,6 +440,12 @@ function pfQuestConfig:UpdateConfigEntries()
   end
 end
 
+function pfQuestConfig:ResetConfigFrames(config)
+  configframes = {}
+  pfQuestConfig:CreateConfigEntries(config)
+  pfQuestConfig:UpdateConfigEntries()
+end
+
 do -- welcome/init popup dialog
   local config_stage = {
     arrow = 1,


### PR DESCRIPTION
Allow to modify config with external values from other extensions
e.g. `pfQuest-twow/overwrites.lua`
![image](https://github.com/shagu/pfQuest/assets/45651092/3b357f41-1f13-4087-b6b5-c88875d377e3)