### PR TITLE
Added server querying for wotlk 3.3.5a

### DIFF
--- a/database.lua
+++ b/database.lua
@@ -1717,6 +1717,8 @@ function pfDatabase:QueryServer()
   frame:RegisterEvent("QUEST_QUERY_COMPLETE")  -- Register the event on the frame
 
   local function OnQuestQueryComplete()
+    frame:UnregisterEvent("QUEST_QUERY_COMPLETE")  -- Unregister the event once it's triggered
+
     -- Retrieve completed quests after the QUEST_QUERY_COMPLETE event
     local completedQuests = GetQuestsCompleted()
 
@@ -1724,6 +1726,9 @@ function pfDatabase:QueryServer()
       for questID, _ in pairs(completedQuests) do
         pfQuest_history[questID] = { time(), UnitLevel("player") }
       end
+
+      -- Reset all quest markers after processing completed quests
+      pfQuest:ResetAll()
     elseif completedQuests == nil then
       -- Handle the case where GetQuestsCompleted() returned nil
       print("Error: GetQuestsCompleted() returned nil.")
@@ -1731,9 +1736,6 @@ function pfDatabase:QueryServer()
       -- Handle the case where GetQuestsCompleted() did not return a valid table
       print("Error: GetQuestsCompleted() did not return a valid table. Value: ", completedQuests)
     end
-	
-	frame:UnregisterEvent("QUEST_QUERY_COMPLETE")
-	
   end
 
   frame:SetScript("OnEvent", OnQuestQueryComplete)  -- Set the event handler

--- a/database.lua
+++ b/database.lua
@@ -1709,3 +1709,32 @@ end)
 function pfDatabase:ScanServer()
   pfServerScan:Show()
 end
+
+function pfDatabase:QueryServer()
+  QueryQuestsCompleted()  -- Send the request to the server
+
+  local frame = CreateFrame("Frame")  -- Create a new frame
+  frame:RegisterEvent("QUEST_QUERY_COMPLETE")  -- Register the event on the frame
+
+  local function OnQuestQueryComplete()
+    -- Retrieve completed quests after the QUEST_QUERY_COMPLETE event
+    local completedQuests = GetQuestsCompleted()
+
+    if type(completedQuests) == "table" then
+      for questID, _ in pairs(completedQuests) do
+        pfQuest_history[questID] = { time(), UnitLevel("player") }
+      end
+    elseif completedQuests == nil then
+      -- Handle the case where GetQuestsCompleted() returned nil
+      print("Error: GetQuestsCompleted() returned nil.")
+    else
+      -- Handle the case where GetQuestsCompleted() did not return a valid table
+      print("Error: GetQuestsCompleted() did not return a valid table. Value: ", completedQuests)
+    end
+	
+	frame:UnregisterEvent("QUEST_QUERY_COMPLETE")
+	
+  end
+
+  frame:SetScript("OnEvent", OnQuestQueryComplete)  -- Set the event handler
+end

--- a/slashcmd.lua
+++ b/slashcmd.lua
@@ -30,6 +30,7 @@ SlashCmdList["PFDB"] = function(input, editbox)
     DEFAULT_CHAT_FRAME:AddMessage("|cff33ffcc/db|cffffffff herbs [min, [max]] |cffcccccc - " .. pfQuest_Loc["Show herbs with skill range of [min] to [max]"])
     DEFAULT_CHAT_FRAME:AddMessage("|cff33ffcc/db|cffffffff herbs auto |cffcccccc - " .. pfQuest_Loc["Show herbs with an appropriate skill level for your character"])
     DEFAULT_CHAT_FRAME:AddMessage("|cff33ffcc/db|cffffffff scan |cffcccccc - " .. pfQuest_Loc["Scan the server for custom items"])
+    DEFAULT_CHAT_FRAME:AddMessage("|cff33ffcc/db|cffffffff query |cffcccccc - " .. pfQuest_Loc["Query the server for completed quests - WIP"])
     return
   end
 
@@ -211,6 +212,12 @@ SlashCmdList["PFDB"] = function(input, editbox)
   -- argument: scan
   if (arg1 == "scan") then
     pfDatabase:ScanServer()
+    return
+  end
+
+    -- argument: query
+  if (arg1 == "query") then
+    pfDatabase:QueryServer()
     return
   end
 


### PR DESCRIPTION
Added server querying for wotlk 3.3.5a through QueryCompletedQuests()/GetCompletedQuests() APIs

- [x] Queries the server for completed quests 
- [x] Populates the playerdb with the quests as completed (uses "pfQuest_history")
- [x] Removes the quest marks of the map/minimap after populating the playerdb (Only removes the questmarks of the map/minimap after a reload, if there is a way to do it without a reload, please tell me how to)


Added a new slashcommand argument "query" to call a new function.

I'm not a developer at all, did this through WebSearch, WoW's API documentation and copy-paste from other parts of the code; sorry if it is not up to standard.
