### PR TITLE
Fix Quest ID guesser

### DIFF
--- a/database.lua
+++ b/database.lua
@@ -1453,7 +1453,7 @@ function pfDatabase:GetQuestIDs(qid)
   if GetQuestLink then
     local questLink = GetQuestLink(qid)
       if questLink then
-      local _, _, id = strfind(questLink, "|c.*|Hquest:([%d]+):([%d]+)|h%[(.*)%]|h|r")
+      local _, _, id = strfind(questLink, "|c.*|Hquest:([%d]+):([-]?[%d]+)|h%[(.*)%]|h|r")
       if id then return { [1] = tonumber(id) } end
     end
   end


### PR DESCRIPTION
Basically this allows for a negative value in the quest link for the quest

Example being https://www.wowhead.com/wotlk/quest=1528/call-of-water

/script DEFAULT_CHAT_FRAME:AddMessage("\124cffffff00\124Hquest:1528:-1\124h[Call of Water]\124h\124r");

for some reason on wrath they made it -1 instead of 20 this should not hurt vanilla or tbc seeing the negative is optional and I dont think they are used there.